### PR TITLE
Add integrity hashes to link tag preloads

### DIFF
--- a/src/sri-plugin.js
+++ b/src/sri-plugin.js
@@ -35,11 +35,11 @@ async function onPostBuild (args, pluginOptions) {
     const addition = `integrity="${hash}"${crossorigin}`
     if (curr.endsWith('.css')) { prev.from.push(`data-href="${curr}"`); prev.to.push(`data-href="${curr}" ${addition}`) }
     if (curr.endsWith('.js')) {
-      prev.from.push(`src="${curr}"`);
-      prev.to.push(`src="${curr}" ${addition}`);
+      prev.from.push(`src="${curr}"`)
+      prev.to.push(`src="${curr}" ${addition}`)
 
-      prev.from.push(`href="${curr}"`);
-      prev.to.push(`href="${curr}" ${addition}`);
+      prev.from.push(`href="${curr}"`)
+      prev.to.push(`href="${curr}" ${addition}`)
     }
     return prev
   }, { files: ['public/**/*.html'], from: [], to: [] })

--- a/src/sri-plugin.js
+++ b/src/sri-plugin.js
@@ -34,7 +34,13 @@ async function onPostBuild (args, pluginOptions) {
     const crossorigin = (options.crossorigin) ? ' crossorigin="anonymous"' : ''
     const addition = `integrity="${hash}"${crossorigin}`
     if (curr.endsWith('.css')) { prev.from.push(`data-href="${curr}"`); prev.to.push(`data-href="${curr}" ${addition}`) }
-    if (curr.endsWith('.js')) { prev.from.push(`src="${curr}"`); prev.to.push(`src="${curr}" ${addition}`) }
+    if (curr.endsWith('.js')) {
+      prev.from.push(`src="${curr}"`);
+      prev.to.push(`src="${curr}" ${addition}`);
+
+      prev.from.push(`href="${curr}"`);
+      prev.to.push(`href="${curr}" ${addition}`);
+    }
     return prev
   }, { files: ['public/**/*.html'], from: [], to: [] })
 


### PR DESCRIPTION
Each page that Gatsby builds includes `<link>` preloads, both as `script` and `fetch` types, added to the bottom of the head tag. This plugin currently only replaces `src` attributes for `.js` files, but preloads use `href` attributes. This provides support to also replace `href` attributes and avoid both errors and warnings in the console that prevent the preloads from working.