### PR TITLE
Add support for gatsby's `pathPrefix` option

### DIFF
--- a/src/sri-plugin.js
+++ b/src/sri-plugin.js
@@ -10,7 +10,8 @@ const util = require('util')
 const defaultOptions = {
   hash: 'sha512',
   extensions: ['css', 'js'],
-  crossorigin: false
+  crossorigin: false,
+  pathPrefix: ''
 }
 
 const globAsync = util.promisify(glob)
@@ -25,7 +26,7 @@ async function onPostBuild (args, pluginOptions) {
   const assetHashes = assets.reduce((prev, curr) => {
     const content = fs.readFileSync(path.join(fileBasePath, curr), 'utf8')
     const assetHash = crypto.createHash(options.hash).update(content, 'utf-8').digest('base64')
-    prev[`/${curr}`] = `${options.hash}-${assetHash}`
+    prev[`${options.pathPrefix}/${curr}`] = `${options.hash}-${assetHash}`
     return prev
   }, {})
 


### PR DESCRIPTION
If `pathPrefix` ([docs](https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/path-prefix/)) is defined in Gatsby's config, it will be automatically
prepended to all local `src`, `href`, etc paths. This causes the SRI
plugin's search+replace to fail if it uses only the local filesystem
path to derive a search pattern.

This patch allows the plugin to take its own `pathPrefix` option which
will then be prefixed to all search/replace patterns.

_**Note:** it would be ideal to get the prefix value from gatsby's config instead of having to pass the prefix to the plugin separately, but I have no found a way for plugins to access higher-level configuration options like that._