### PR TITLE
Add new assetPrefix option to specify a domain/path if you use assetPrefix in gatsby-config.js

### DIFF
--- a/src/sri-plugin.js
+++ b/src/sri-plugin.js
@@ -10,7 +10,8 @@ const util = require('util')
 const defaultOptions = {
   hash: 'sha512',
   extensions: ['css', 'js'],
-  crossorigin: false
+  crossorigin: false,
+  assetPrefix: ''
 }
 
 const globAsync = util.promisify(glob)
@@ -31,15 +32,19 @@ async function onPostBuild (args, pluginOptions) {
 
   const replaceOptions = Object.keys(assetHashes).reduce((prev, curr) => {
     const hash = assetHashes[curr]
+    const assetPrefix = options.assetPrefix.replace(/\/$/, '')
     const crossorigin = (options.crossorigin) ? ' crossorigin="anonymous"' : ''
     const addition = `integrity="${hash}"${crossorigin}`
-    if (curr.endsWith('.css')) { prev.from.push(`data-href="${curr}"`); prev.to.push(`data-href="${curr}" ${addition}`) }
+    if (curr.endsWith('.css')) { 
+      prev.from.push(`data-href="${assetPrefix}${curr}"`)
+      prev.to.push(`data-href="${assetPrefix}${curr}" ${addition}`) 
+    }
     if (curr.endsWith('.js')) {
-      prev.from.push(`src="${curr}"`)
-      prev.to.push(`src="${curr}" ${addition}`)
+      prev.from.push(`src="${assetPrefix}${curr}"`)
+      prev.to.push(`src="${assetPrefix}${curr}" ${addition}`)
 
-      prev.from.push(`href="${curr}"`)
-      prev.to.push(`href="${curr}" ${addition}`)
+      prev.from.push(`href="${assetPrefix}${curr}"`)
+      prev.to.push(`href="${assetPrefix}${curr}" ${addition}`)
     }
     return prev
   }, { files: ['public/**/*.html'], from: [], to: [] })


### PR DESCRIPTION
Hi @ovhemert 

First, thank you for this SRI plugin!
While using it I encountered a problem when using the gatsby SRI plugin in combination with an assetPrefix option set in gatsby-config.js.

If you specify an assetPrefix in gatsby-config.js it won't be updating the HTML files in public/ with the integrity attribute because `replace-in-file` cannot find a match because the assetPrefix value is in between the src attr and the asset file name.

**Example:**
* assetPrefix set to `https://static.mydomain.tld/blog/` in `gatsby-config.js` (https://www.gatsbyjs.com/docs/how-to/previews-deploys-hosting/asset-prefix/)
* Example JS file generated by Gatsby: `/app-d00ac0abbcbded466c31.js`
* The SRI plugin wants to add the integrity attr by replacing `src="/app-d00ac0abbcbded466c31.js"` with `src="/app-d00ac0abbcbded466c31.js" integrity="xxx"`
* My HTML file uses the assetPrefix from Gatsby to host static assets on another subdomain and path (https://static.mydomain.tld/blog/)
* My generated HTML files, after a Gatsby build, in public/ have a src like this: 
```
<script src="https://static.mydomain.tld/blog/polyfill-e8c05f5fcd70e248bd00.js" nomodule=""></script>
```
* So the match cannot be done because `https://static.mydomain.tld/blog/` is added by Gatsby and the replace fails
* By adding a new (optional) assetPrefix option with a default value of '' we can make the replace work when assets are hosted on another domain / path.

Did you already encounter this? Any suggestions to change this PR?
If you agree with the changes some docs still needs to be added I guess...

Thanks in advance.